### PR TITLE
feat: Add whitepaper reference. Thanks Philip!

### DIFF
--- a/_posts/2023-07-13-understanding-proactive-initialization.md
+++ b/_posts/2023-07-13-understanding-proactive-initialization.md
@@ -87,6 +87,8 @@ AWS Lambda is a distributed service. Worker fleets need to be redeployed, scaled
 
 This means that even with steady-state throughput, Lambda will need to rotate function sandboxes for users over the course of hours or days. AWS does not publish minimum or maximum lease durations for a function sandbox, although in practice I've observed ~7 minutes on the low side and several hours on the high side.
 
+>Update: An [AWS whitepaper](https://docs.aws.amazon.com/pdfs/whitepapers/latest/security-overview-aws-lambda/security-overview-aws-lambda.pdf) states that the maximum lease lifetime for a worker sandbox is 14 hours. Thanks to [Philip Potter](https://twitter.com/philandstuff/status/1693579220021108817) for pointing this out!
+
 The service also needs to run efficiently, combining as many functions onto one machine as possible. In distributed systems parlance, this is known as `bin packing` (aka shoving as much stuff as possible into the same bucket).
 
 The less time spent initializing functions which AWS *knows* will serve invocations, the better for everyone.


### PR DESCRIPTION
Adding a reference to the AWS whitepaper stating max lease is 14 hours.